### PR TITLE
Fix pipeline service export variable

### DIFF
--- a/api.js
+++ b/api.js
@@ -5,7 +5,7 @@ const leadApi = require('./services/leads');
 const contactApi = require('./services/contacts');
 const fieldApi = require('./services/fields');
 const userApi = require('./services/users');
-const pipleneApi = require('./services/pipelines');
+const pipelineApi = require('./services/pipelines');
 const tagApi = require('./services/tags');
 const sourcesApi = require('./services/sources');
 
@@ -17,7 +17,7 @@ module.exports = {
   contactApi,
   fieldApi,
   userApi,
-  pipleneApi,
+  pipelineApi,
   tagApi,
   sourcesApi
 };


### PR DESCRIPTION
## Summary
- fix typo in `api.js` for pipelines service import and export

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails to resolve module `globals`)*

------
https://chatgpt.com/codex/tasks/task_e_6846fc90fcd0832fa2ceac7a5bff77c1