### PR TITLE
Fix MD5 header handling

### DIFF
--- a/services/chat.js
+++ b/services/chat.js
@@ -71,7 +71,10 @@ module.exports = {
     const [cleanPath] = path.split('?');
     const date = new Date().toUTCString() || '';
     const content_type = 'application/json';
-    const content_md5 = crypto.createHash('md5').update(body).digest('hex') || '';
+    let content_md5 = '';
+    if (body) {
+      content_md5 = crypto.createHash('md5').update(body).digest('base64');
+    }
     const secret = [method, content_md5, content_type, date, cleanPath].join('\n');
     const x_secret = crypto.createHmac('sha1', this.AMO_CHANEL_SECRET).update(secret).digest('hex');
     const headers = {


### PR DESCRIPTION
## Summary
- ensure `Content-MD5` uses base64 encoding in chat headers
- keep `Content-MD5` empty when no body is sent

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_6846fda5c778832f87ea0e8b5bec87ce